### PR TITLE
Update PHP version requirement to include 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.3||^8.4",
         "spatie/laravel-package-tools": "^1.16",
         "illuminate/contracts": "^10.0||^11.0||^12.0"
     },


### PR DESCRIPTION
```
php -v
PHP 8.4.3 (cli) (built: Jan 15 2025 11:02:41) (NTS Visual C++ 2022 x64)
Copyright (c) The PHP Group
Zend Engine v4.4.3, Copyright (c) Zend Technologies
```

```
Tests:    42 passed (193 assertions)
Duration: 3.64s
Random Order Seed: 1759911332
```