### PR TITLE
Add version column to rewind_versions table index

### DIFF
--- a/database/migrations/create_rewind_versions_table.php.stub
+++ b/database/migrations/create_rewind_versions_table.php.stub
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->unsignedBigInteger('user_id')->nullable();
             $table->timestamps();
 
-            $table->index(['model_type', 'model_id']);
+            $table->index(['model_type', 'model_id', 'version']);
         });
     }
 


### PR DESCRIPTION
## Summary
Updated the database migration for the rewind_versions table to include the `version` column in the composite index alongside `model_type` and `model_id`.

## Key Changes
- Modified the composite index on the `rewind_versions` table from `['model_type', 'model_id']` to `['model_type', 'model_id', 'version']`

## Implementation Details
This change improves query performance for lookups that filter by model type, model ID, and version together. By including the `version` column in the index, database queries that commonly filter on all three columns can now utilize the index more efficiently, reducing the need for additional table scans.

https://claude.ai/code/session_0123Gu3DDmdDHfZTqxU6hDjz