### PR TITLE
Implement buffered auto-pruning with snapshot interval

### DIFF
--- a/config/rewind.php
+++ b/config/rewind.php
@@ -125,8 +125,10 @@ return [
     |--------------------------------------------------------------------------
     |
     | If set, the package will automatically prune old versions after creating
-    | a new one, keeping at most this many versions per model instance. This
-    | can be overridden per-model by defining a $maxRewindVersions property.
+    | a new one, keeping at most this many versions per model instance. Pruning
+    | is batched using snapshot_interval as a buffer — versions accumulate to
+    | max_versions + snapshot_interval before pruning back to max_versions.
+    | This can be overridden per-model by defining a maxRewindVersions() method.
     | Set to null to disable automatic pruning.
     |
     */

--- a/src/Listeners/CreateRewindVersion.php
+++ b/src/Listeners/CreateRewindVersion.php
@@ -236,6 +236,16 @@ class CreateRewindVersion
             return;
         }
 
+        $snapshotInterval = (int) config('rewind.snapshot_interval', 10);
+
+        $versionCount = RewindVersion::where('model_type', $model->getMorphClass())
+            ->where('model_id', $model->getKey())
+            ->count();
+
+        if ($versionCount <= $maxVersions + $snapshotInterval) {
+            return;
+        }
+
         app(VersionPruner::class)->pruneForModel($model, (int) $maxVersions);
     }
 }

--- a/tests/Feature/Listeners/AutoPruneTest.php
+++ b/tests/Feature/Listeners/AutoPruneTest.php
@@ -32,11 +32,26 @@ it('does not auto-prune when max_versions is null', function () {
     expect(RewindVersion::count())->toBe(10);
 });
 
-it('auto-prunes when global max_versions config is set', function () {
+it('does not auto-prune within the buffer window', function () {
     config()->set('rewind.max_versions', 5);
+    config()->set('rewind.snapshot_interval', 3);
 
     $post = Post::create(['user_id' => $this->user->id, 'title' => 'v1', 'body' => 'body']);
+    // Create 8 total versions (max 5 + interval 3 = 8, so <= threshold)
     for ($i = 2; $i <= 8; $i++) {
+        $post->update(['title' => "v{$i}"]);
+    }
+
+    expect(RewindVersion::count())->toBe(8);
+});
+
+it('auto-prunes when buffer is exceeded', function () {
+    config()->set('rewind.max_versions', 5);
+    config()->set('rewind.snapshot_interval', 3);
+
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'v1', 'body' => 'body']);
+    // Create 9 total versions (max 5 + interval 3 = 8, so 9 > threshold triggers prune)
+    for ($i = 2; $i <= 9; $i++) {
         $post->update(['title' => "v{$i}"]);
     }
 
@@ -44,14 +59,15 @@ it('auto-prunes when global max_versions config is set', function () {
 
     // The latest 5 versions should remain
     $versions = RewindVersion::orderBy('version')->pluck('version')->toArray();
-    expect($versions)->toBe([4, 5, 6, 7, 8]);
+    expect($versions)->toBe([5, 6, 7, 8, 9]);
 });
 
 it('ensures oldest remaining version is a snapshot after auto-prune', function () {
     config()->set('rewind.max_versions', 3);
-    config()->set('rewind.snapshot_interval', 10);
+    config()->set('rewind.snapshot_interval', 2);
 
     $post = Post::create(['user_id' => $this->user->id, 'title' => 'v1', 'body' => 'body']);
+    // Threshold is 3 + 2 = 5, so 6 versions triggers prune
     for ($i = 2; $i <= 6; $i++) {
         $post->update(['title' => "v{$i}"]);
     }


### PR DESCRIPTION
## Summary
This PR implements a buffered auto-pruning strategy for version management that uses the `snapshot_interval` configuration as a grace period before pruning occurs. Instead of pruning immediately when `max_versions` is reached, versions now accumulate up to `max_versions + snapshot_interval` before being pruned back down to `max_versions`.

## Key Changes
- **Buffered pruning logic**: Modified `autoPruneIfNeeded()` in `CreateRewindVersion` to check if version count exceeds the threshold (`max_versions + snapshot_interval`) before triggering pruning
- **Configuration documentation**: Updated `config/rewind.php` to clarify that pruning is batched using `snapshot_interval` as a buffer, and corrected the reference to use `maxRewindVersions()` method instead of property
- **Test coverage**: Refactored and expanded tests to validate:
  - Versions accumulate within the buffer window without pruning
  - Pruning is triggered only when the buffer threshold is exceeded
  - The oldest remaining version after pruning is a snapshot

## Implementation Details
- The buffer threshold is calculated as `max_versions + snapshot_interval`
- Pruning only occurs when `versionCount > (max_versions + snapshot_interval)`
- This approach reduces unnecessary pruning operations while maintaining version history within a predictable range
- The implementation respects per-model overrides via the `maxRewindVersions()` method

https://claude.ai/code/session_01WQUGsZqzFLPm1ThSiuREUd