### PR TITLE
Fix rewind event dispatch timing for soft deletes

### DIFF
--- a/src/Traits/Rewindable.php
+++ b/src/Traits/Rewindable.php
@@ -52,20 +52,25 @@ trait Rewindable
             $model->dispatchRewindEvent();
         });
 
-        static::deleting(function ($model) {
-            // Only dispatch a rewind event if the model is not force deleting
-            if ($model->hasSoftDeletes() && ! $model->isForceDeleting()) {
-
-                // Ensure `deleted_at` shows up as dirty
-                $model->forceFill([$model->getDeletedAtColumn() => $model->freshTimestampString()]);
-
-                $model->dispatchRewindEvent();
-            }
-        });
-
         static::deleted(function ($model) {
-            // If the model is force deleting or does not use soft deletes, delete all versions
-            if (! $model->hasSoftDeletes() || $model->isForceDeleting()) {
+            if ($model->hasSoftDeletes() && ! $model->isForceDeleting()) {
+                // Soft delete: dispatch rewind event after Eloquent has set deleted_at,
+                // so the version records the exact timestamp stored in the database.
+                // runSoftDelete() calls syncOriginalAttributes() which syncs the original
+                // to match the current value, losing the dirty state. We restore it by
+                // temporarily clearing deleted_at, syncing original to null, then setting
+                // it back so getDirty() and getOriginal() reflect the actual change.
+                $deletedAtColumn = $model->getDeletedAtColumn();
+                $deletedAt = $model->getAttribute($deletedAtColumn);
+                $model->setAttribute($deletedAtColumn, null);
+                $model->syncOriginalAttributes([$deletedAtColumn]);
+                $model->setAttribute($deletedAtColumn, $deletedAt);
+                $model->dispatchRewindEvent();
+                // Restore proper state so subsequent operations (e.g. restore) see
+                // the correct original deleted_at value.
+                $model->syncOriginalAttributes([$deletedAtColumn]);
+            } else {
+                // Force delete or no soft deletes: remove all versions
                 $model->versions()->delete();
             }
         });


### PR DESCRIPTION
## Summary
This change fixes the timing of when rewind events are dispatched for soft-deleted models. The event is now dispatched in the `deleted` hook instead of the `deleting` hook, and includes logic to properly restore the dirty state of the `deleted_at` attribute so that version records capture the correct timestamp.

## Key Changes
- Moved rewind event dispatch from `deleting` to `deleted` hook to ensure it fires after Eloquent has set the `deleted_at` timestamp
- Implemented a workaround to restore the dirty state of `deleted_at` since Eloquent's `runSoftDelete()` syncs original attributes, losing the change tracking
- The fix temporarily clears `deleted_at`, syncs original attributes to null, then restores the value so `getDirty()` and `getOriginal()` properly reflect the soft delete change
- Consolidated force delete and soft delete logic into a single `deleted` hook with conditional branches
- Removed the now-unused `deleting` hook

## Implementation Details
The core issue was that `runSoftDelete()` calls `syncOriginalAttributes()`, which syncs the original `deleted_at` value to match the current value, causing the attribute to no longer appear as "dirty". By the time the rewind event was dispatched, the version record couldn't detect the change. The solution manipulates the attribute state to restore the dirty tracking while preserving the correct database timestamp for the version record.

https://claude.ai/code/session_01TQo2CegSiEMwJtzhweeduh