### PR TITLE
Add replay API (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `laravel-rewind` will be documented in this file.
 ### New Features
 
 * **State transition tracking** -- Designate fields as state fields via `$rewindStateFields` on your model. Rewind records structured `from`/`to` transitions alongside each version. Query with `whereStateBecame()`, `whereStateWas()`, `whereStateChanged()`, and `whereStateTransition()` scopes, or get a full timeline with `$model->stateHistory($field)`.
+* **Replay API** -- `Rewind::replay($model, $from, $to, $callback)` iterates through version history with fully reconstructed state at each step. Supports forward and reverse replay. Callback return values are collected into a `Collection`. State is built incrementally for performance.
 
 ### Migration
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,31 @@ $diff->isEmpty(); // false
 
 Works in either direction. `diff($post, 5, 1)` swaps old and new.
 
+### Replay through history
+
+Walk through a range of versions with the fully reconstructed state at each step:
+
+```php
+Rewind::replay($post, 1, 10, function (RewindVersion $version, array $attributes) {
+    // $version is the RewindVersion record (with meta, event_type, etc.)
+    // $attributes is the complete model state at that version
+});
+```
+
+Callback return values are collected into a `Collection`, so you can use it as a map:
+
+```php
+$titles = Rewind::replay($post, 1, 10, function (RewindVersion $version, array $attributes) {
+    return $attributes['title'];
+});
+
+// Collection(['Draft', 'Review', 'Published', ...])
+```
+
+Works in reverse too. `replay($post, 10, 1)` walks backward from v10 to v1.
+
+State is reconstructed incrementally, not independently per version, so this stays fast even over large ranges.
+
 ### Build a specific version's attributes
 
 Diffs don't always contain all the data for a version. This method reconstructs the full attribute set:

--- a/src/Contracts/RewindManagerInterface.php
+++ b/src/Contracts/RewindManagerInterface.php
@@ -10,6 +10,7 @@ use AvocetShores\LaravelRewind\Exceptions\VersionDoesNotExistException;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 
 interface RewindManagerInterface
 {
@@ -99,4 +100,14 @@ interface RewindManagerInterface
      * instead of creating new version records.
      */
     public function amendCurrentVersion(callable $callback): mixed;
+
+    /**
+     * Iterate through version history with fully reconstructed state at each step.
+     * Callback return values are collected into the returned Collection.
+     *
+     * @throws ModelNotRewindableException
+     * @throws VersionDoesNotExistException
+     * @throws CurrentVersionColumnMissingException
+     */
+    public function replay(Model $model, int $fromVersion, int $toVersion, callable $callback): Collection;
 }

--- a/src/Facades/Rewind.php
+++ b/src/Facades/Rewind.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void withMeta(array $meta) Set metadata to attach to the next version created
  * @method static string batch(callable $callback) Group multiple changes into a single batch, returns batch UUID
  * @method static mixed amendCurrentVersion(callable $callback) Execute callback where changes amend the current version
+ * @method static \Illuminate\Support\Collection replay(Model $model, int $fromVersion, int $toVersion, callable $callback) Iterate through version history with reconstructed state at each step
  */
 class Rewind extends Facade
 {

--- a/src/Services/RewindManager.php
+++ b/src/Services/RewindManager.php
@@ -16,6 +16,7 @@ use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class RewindManager implements RewindManagerInterface
@@ -261,6 +262,65 @@ class RewindManager implements RewindManagerInterface
         $toAttrs = $this->getVersionAttributes($model, $toVersion);
 
         return VersionDiff::fromAttributes($fromAttrs, $toAttrs);
+    }
+
+    /**
+     * Iterate through version history with fully reconstructed state at each step.
+     *
+     * @throws ModelNotRewindableException
+     * @throws VersionDoesNotExistException
+     * @throws CurrentVersionColumnMissingException
+     */
+    public function replay(Model $model, int $fromVersion, int $toVersion, callable $callback): Collection
+    {
+        $this->assertRewindable($model);
+        $this->eagerLoadVersions($model);
+
+        $versions = $model->versions; // @phpstan-ignore property.notFound
+
+        // Validate both endpoints exist
+        if (! $versions->where('version', $fromVersion)->first()) {
+            throw new VersionDoesNotExistException('The specified version does not exist.');
+        }
+        if (! $versions->where('version', $toVersion)->first()) {
+            throw new VersionDoesNotExistException('The specified version does not exist.');
+        }
+
+        $currentVersion = $this->determineCurrentVersion($model);
+        $currentAttributes = Arr::except(
+            $model->attributesToArray(),
+            $model->getExcludedRewindableAttributes() // @phpstan-ignore method.notFound
+        );
+
+        $stateMap = $this->stateBuilder->buildStateSequence(
+            versions: $versions,
+            currentVersion: $currentVersion,
+            fromVersion: $fromVersion,
+            toVersion: $toVersion,
+            currentAttributes: $currentAttributes,
+        );
+
+        $results = [];
+        $min = min($fromVersion, $toVersion);
+        $max = max($fromVersion, $toVersion);
+
+        $versionRecords = $versions
+            ->where('version', '>=', $min)
+            ->where('version', '<=', $max);
+
+        if ($fromVersion <= $toVersion) {
+            $versionRecords = $versionRecords->sortBy('version');
+        } else {
+            $versionRecords = $versionRecords->sortByDesc('version');
+        }
+
+        foreach ($versionRecords as $versionRec) {
+            if (isset($stateMap[$versionRec->version])) {
+                $results[] = $callback($versionRec, $stateMap[$versionRec->version]);
+            }
+        }
+
+        return collect($results);
     }
 
     /**

--- a/src/Services/StateBuilder.php
+++ b/src/Services/StateBuilder.php
@@ -117,21 +117,26 @@ class StateBuilder
         } else {
             // Stepping backward: apply old_values from each version to undo it.
             // Applying version N's old_values produces the state at version N-1.
-            $steppingVersions = $versions
-                ->where('version', '>', $toVersion)
+            // Pre-collect version numbers in ascending order so we can map each
+            // version to its predecessor via index lookup (O(n) total, not O(n^2)).
+            $rangeVersions = $versions
+                ->where('version', '>=', $toVersion)
                 ->where('version', '<=', $fromVersion)
-                ->sortByDesc('version');
+                ->sortBy('version')
+                ->values();
+
+            $indexByVersion = $rangeVersions->mapWithKeys(
+                fn ($v, $i) => [$v->version => $i]
+            );
+
+            $steppingVersions = $rangeVersions->reverse();
 
             foreach ($steppingVersions as $versionRec) {
                 $attributes = array_merge($attributes, $versionRec->old_values ?? []);
-                $previousVersion = $versions
-                    ->where('version', '<', $versionRec->version)
-                    ->where('version', '>=', $toVersion)
-                    ->sortByDesc('version')
-                    ->first();
+                $idx = $indexByVersion[$versionRec->version];
 
-                if ($previousVersion) {
-                    $states[$previousVersion->version] = $attributes;
+                if ($idx > 0) {
+                    $states[$rangeVersions[$idx - 1]->version] = $attributes;
                 }
             }
         }

--- a/src/Services/StateBuilder.php
+++ b/src/Services/StateBuilder.php
@@ -78,6 +78,68 @@ class StateBuilder
     }
 
     /**
+     * Build reconstructed state at each version in a range, stepping incrementally.
+     *
+     * Reconstructs state at $fromVersion once (using ApproachEngine), then steps
+     * through each subsequent version applying diffs to capture intermediate states.
+     *
+     * @return array<int, array> Reconstructed attributes keyed by version number
+     */
+    public function buildStateSequence(
+        Collection $versions,
+        int $currentVersion,
+        int $fromVersion,
+        int $toVersion,
+        array $currentAttributes = [],
+    ): array {
+        $startState = $this->buildStateForVersion(
+            $versions, $currentVersion, $fromVersion, $currentAttributes,
+        );
+
+        $states = [$fromVersion => $startState];
+
+        if ($fromVersion === $toVersion) {
+            return $states;
+        }
+
+        $attributes = $startState;
+
+        if ($fromVersion < $toVersion) {
+            $steppingVersions = $versions
+                ->where('version', '>', $fromVersion)
+                ->where('version', '<=', $toVersion)
+                ->sortBy('version');
+
+            foreach ($steppingVersions as $versionRec) {
+                $attributes = array_merge($attributes, $versionRec->new_values ?? []);
+                $states[$versionRec->version] = $attributes;
+            }
+        } else {
+            // Stepping backward: apply old_values from each version to undo it.
+            // Applying version N's old_values produces the state at version N-1.
+            $steppingVersions = $versions
+                ->where('version', '>', $toVersion)
+                ->where('version', '<=', $fromVersion)
+                ->sortByDesc('version');
+
+            foreach ($steppingVersions as $versionRec) {
+                $attributes = array_merge($attributes, $versionRec->old_values ?? []);
+                $previousVersion = $versions
+                    ->where('version', '<', $versionRec->version)
+                    ->where('version', '>=', $toVersion)
+                    ->sortByDesc('version')
+                    ->first();
+
+                if ($previousVersion) {
+                    $states[$previousVersion->version] = $attributes;
+                }
+            }
+        }
+
+        return $states;
+    }
+
+    /**
      * Step through version diffs from one version to another, applying
      * old_values (backward) or new_values (forward) as appropriate.
      *

--- a/tests/Feature/Services/ReplayTest.php
+++ b/tests/Feature/Services/ReplayTest.php
@@ -8,6 +8,7 @@ use AvocetShores\LaravelRewind\Tests\Models\Post;
 use AvocetShores\LaravelRewind\Tests\Models\PostThatIsNotRewindable;
 use AvocetShores\LaravelRewind\Tests\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
 
 uses(RefreshDatabase::class);
 
@@ -61,7 +62,7 @@ it('collects callback return values into a Collection', function () {
         return 'v'.$version->version.':'.$attributes['title'];
     });
 
-    expect($result)->toBeInstanceOf(\Illuminate\Support\Collection::class);
+    expect($result)->toBeInstanceOf(Collection::class);
     expect($result->all())->toBe([
         'v1:V1',
         'v2:V2',

--- a/tests/Feature/Services/ReplayTest.php
+++ b/tests/Feature/Services/ReplayTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use AvocetShores\LaravelRewind\Exceptions\ModelNotRewindableException;
+use AvocetShores\LaravelRewind\Exceptions\VersionDoesNotExistException;
+use AvocetShores\LaravelRewind\Facades\Rewind;
+use AvocetShores\LaravelRewind\Models\RewindVersion;
+use AvocetShores\LaravelRewind\Tests\Models\Post;
+use AvocetShores\LaravelRewind\Tests\Models\PostThatIsNotRewindable;
+use AvocetShores\LaravelRewind\Tests\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::create([
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+    ]);
+    test()->actingAs($this->user);
+});
+
+it('calls the callback for each version with reconstructed attributes', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1 Title', 'body' => 'V1 Body']);
+    $post->update(['title' => 'V2 Title']);
+    $post->update(['title' => 'V3 Title']);
+
+    $collected = [];
+    Rewind::replay($post, 1, 3, function (RewindVersion $version, array $attributes) use (&$collected) {
+        $collected[$version->version] = $attributes['title'];
+    });
+
+    expect($collected)->toBe([
+        1 => 'V1 Title',
+        2 => 'V2 Title',
+        3 => 'V3 Title',
+    ]);
+});
+
+it('provides RewindVersion instances with full metadata', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1', 'body' => 'Body']);
+    $post->update(['title' => 'V2']);
+
+    $versions = [];
+    Rewind::replay($post, 1, 2, function (RewindVersion $version, array $attributes) use (&$versions) {
+        $versions[] = $version;
+    });
+
+    expect($versions)->toHaveCount(2);
+    expect($versions[0])->toBeInstanceOf(RewindVersion::class);
+    expect($versions[0]->version)->toBe(1);
+    expect($versions[1]->version)->toBe(2);
+});
+
+it('collects callback return values into a Collection', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1', 'body' => 'Body']);
+    $post->update(['title' => 'V2']);
+    $post->update(['title' => 'V3']);
+
+    $result = Rewind::replay($post, 1, 3, function (RewindVersion $version, array $attributes) {
+        return 'v'.$version->version.':'.$attributes['title'];
+    });
+
+    expect($result)->toBeInstanceOf(\Illuminate\Support\Collection::class);
+    expect($result->all())->toBe([
+        'v1:V1',
+        'v2:V2',
+        'v3:V3',
+    ]);
+});
+
+it('handles single version replay where from equals to', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1 Title', 'body' => 'V1 Body']);
+    $post->update(['title' => 'V2 Title']);
+
+    $callCount = 0;
+    Rewind::replay($post, 2, 2, function (RewindVersion $version, array $attributes) use (&$callCount) {
+        $callCount++;
+        expect($version->version)->toBe(2);
+        expect($attributes['title'])->toBe('V2 Title');
+    });
+
+    expect($callCount)->toBe(1);
+});
+
+it('supports reverse replay when from is greater than to', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1 Title', 'body' => 'V1 Body']);
+    $post->update(['title' => 'V2 Title']);
+    $post->update(['title' => 'V3 Title']);
+
+    $collected = [];
+    Rewind::replay($post, 3, 1, function (RewindVersion $version, array $attributes) use (&$collected) {
+        $collected[$version->version] = $attributes['title'];
+    });
+
+    expect($collected)->toBe([
+        3 => 'V3 Title',
+        2 => 'V2 Title',
+        1 => 'V1 Title',
+    ]);
+});
+
+it('throws when from version does not exist', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1', 'body' => 'Body']);
+
+    Rewind::replay($post, 999, 1, function () {});
+})->throws(VersionDoesNotExistException::class);
+
+it('throws when to version does not exist', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1', 'body' => 'Body']);
+
+    Rewind::replay($post, 1, 999, function () {});
+})->throws(VersionDoesNotExistException::class);
+
+it('throws when model is not rewindable', function () {
+    $post = PostThatIsNotRewindable::create([
+        'user_id' => $this->user->id,
+        'title' => 'Title',
+        'body' => 'Body',
+    ]);
+
+    Rewind::replay($post, 1, 1, function () {});
+})->throws(ModelNotRewindableException::class);
+
+it('works correctly across snapshot boundaries', function () {
+    config()->set('rewind.snapshot_interval', 3);
+
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1', 'body' => 'Body']);
+
+    for ($i = 2; $i <= 12; $i++) {
+        $post->update(['title' => "V{$i}"]);
+    }
+
+    $collected = [];
+    Rewind::replay($post, 1, 12, function (RewindVersion $version, array $attributes) use (&$collected) {
+        $collected[$version->version] = $attributes['title'];
+    });
+
+    expect($collected)->toHaveCount(12);
+    for ($i = 1; $i <= 12; $i++) {
+        expect($collected[$i])->toBe("V{$i}");
+    }
+});
+
+it('does not mutate the model', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1 Title', 'body' => 'V1 Body']);
+    $post->update(['title' => 'V2 Title']);
+    $post->update(['title' => 'V3 Title']);
+
+    $originalVersion = $post->current_version;
+    $originalTitle = $post->title;
+
+    Rewind::replay($post, 1, 3, function () {});
+
+    expect($post->current_version)->toBe($originalVersion);
+    expect($post->title)->toBe($originalTitle);
+});
+
+it('tracks multiple attribute changes across versions', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'T1', 'body' => 'B1']);
+    $post->update(['title' => 'T2', 'body' => 'B2']);
+    $post->update(['body' => 'B3']);
+
+    $collected = [];
+    Rewind::replay($post, 1, 3, function (RewindVersion $version, array $attributes) use (&$collected) {
+        $collected[$version->version] = ['title' => $attributes['title'], 'body' => $attributes['body']];
+    });
+
+    expect($collected)->toBe([
+        1 => ['title' => 'T1', 'body' => 'B1'],
+        2 => ['title' => 'T2', 'body' => 'B2'],
+        3 => ['title' => 'T2', 'body' => 'B3'],
+    ]);
+});

--- a/tests/Feature/Services/ReplayTest.php
+++ b/tests/Feature/Services/ReplayTest.php
@@ -143,6 +143,51 @@ it('works correctly across snapshot boundaries', function () {
     }
 });
 
+it('supports reverse replay across snapshot boundaries', function () {
+    config()->set('rewind.snapshot_interval', 3);
+
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1', 'body' => 'Body']);
+
+    for ($i = 2; $i <= 12; $i++) {
+        $post->update(['title' => "V{$i}"]);
+    }
+
+    $collected = [];
+    Rewind::replay($post, 12, 1, function (RewindVersion $version, array $attributes) use (&$collected) {
+        $collected[$version->version] = $attributes['title'];
+    });
+
+    expect($collected)->toHaveCount(12);
+    for ($i = 1; $i <= 12; $i++) {
+        expect($collected[$i])->toBe("V{$i}");
+    }
+});
+
+it('skips pruned versions in the range', function () {
+    $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1', 'body' => 'Body']);
+    $post->update(['title' => 'V2']);
+    $post->update(['title' => 'V3']);
+    $post->update(['title' => 'V4']);
+    $post->update(['title' => 'V5']);
+
+    // Simulate pruning by deleting version records 2 and 3
+    RewindVersion::where('model_type', $post->getMorphClass())
+        ->where('model_id', $post->getKey())
+        ->whereIn('version', [2, 3])
+        ->delete();
+
+    $collected = [];
+    Rewind::replay($post, 1, 5, function (RewindVersion $version, array $attributes) use (&$collected) {
+        $collected[$version->version] = $attributes['title'];
+    });
+
+    // Only versions 1, 4, 5 remain; pruned versions are skipped
+    expect($collected)->toHaveCount(3);
+    expect($collected)->toHaveKeys([1, 4, 5]);
+    expect($collected[1])->toBe('V1');
+    expect($collected[5])->toBe('V5');
+});
+
 it('does not mutate the model', function () {
     $post = Post::create(['user_id' => $this->user->id, 'title' => 'V1 Title', 'body' => 'V1 Body']);
     $post->update(['title' => 'V2 Title']);


### PR DESCRIPTION
## Summary
- Adds `Rewind::replay($model, $from, $to, $callback)` for iterating through version history with fully reconstructed state at each step
- Uses incremental state building (reconstruct once at start version, then step through diffs) instead of independently reconstructing each version
- Supports forward and reverse replay, collects callback return values into a Collection

## Test plan
- [x] 11 new tests covering forward/reverse replay, single version, return collection, snapshot boundaries, exceptions, immutability
- [x] Full suite passes (201 tests)
- [x] PHPStan clean