### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,12 +18,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [11.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
             carbon: ^2.63
+          - laravel: 12.*
+            testbench: 9.*
+            carbon: ^3.0
+          - laravel: 13.*
+            testbench: 10.*
+            carbon: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -55,7 +61,7 @@ jobs:
         run: vendor/bin/pest --coverage-clover=coverage.xml --min=80
 
       - name: Upload coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.php == '8.3' && startsWith( matrix.laravel, '11') && matrix.stability == 'prefer-stable'
+        if: matrix.os == 'ubuntu-latest' && matrix.php == '8.3' && startsWith( matrix.laravel, '13') && matrix.stability == 'prefer-stable'
         uses: codecov/codecov-action@v5
         with:
             files: ./coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     "require": {
         "php": "^8.3||^8.4",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0||^12.0"
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^9.0.0||^8.22.0",
+        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",


### PR DESCRIPTION
Closes #79

## Changes
- Added `^13.0` to `illuminate/contracts` version constraint
- Added `^10.0.0` to `orchestra/testbench` for Laravel 13 compatibility
- Extended CI matrix to test against Laravel 11, 12, and 13
- Updated Carbon to `^3.0` for Laravel 12 and 13 matrix entries
- Updated Codecov upload condition to run against Laravel 13